### PR TITLE
fix: Rate组件点击后继续移动，错误展示的bug

### DIFF
--- a/packages/concis-react/src/Rate/index.tsx
+++ b/packages/concis-react/src/Rate/index.tsx
@@ -188,12 +188,10 @@ const Rate: FC<rateProps> = (props: rateProps) => {
   const leaveRate = () => {
     //离开整个容器
     if (readonly) return;
-    if (!hasClick) {
-      setStarShowStatus((oldArr: any): Array<boolean | string> => {
-        oldArr = logStarShowStatus;
-        return JSON.parse(JSON.stringify(oldArr));
-      });
-    }
+    setStarShowStatus((oldArr: any): Array<boolean | string> => {
+      oldArr = logStarShowStatus;
+      return JSON.parse(JSON.stringify(oldArr));
+    });
     setHasClick(false);
   };
   const starBg = useCallback(


### PR DESCRIPTION
复现步骤：鼠标移入Rate组件点击后不移出，继续移动后再移出，展示的效果是最后移动的位置，而不是点击的位置
原因：离开容器事件只在 hasClick 为 false 时，即 未进行点击操作 或 进行了清空操作 后才将 真实状态 重置为 记录状态，未考虑上述情况