### PR TITLE
fix: number input

### DIFF
--- a/packages/concis-react/src/Input/demos/index5.tsx
+++ b/packages/concis-react/src/Input/demos/index5.tsx
@@ -12,7 +12,7 @@ export default function InputDemo5() {
     <Input
       type="num"
       placeholder="请输入"
-      min={5}
+      min={0}
       max={10}
       step={1.5}
       handleIptChange={handleIptChange}

--- a/packages/concis-react/src/Input/index.tsx
+++ b/packages/concis-react/src/Input/index.tsx
@@ -58,15 +58,24 @@ const Input: FC<InputProps & NativeInputProps> = (props) => {
     if (moreStyle && Object.keys(moreStyle).includes('caretColor')) {
       return;
     }
-    setIptValue(e.target.value);
-    if (handleIptChange) {
-      handleIptChange(e.target.value);
-    }
+    const val = e.target.value;
+    setIptValue(val);
+    handleIptChange && handleIptChange(val);
   };
   const blurIpt = () => {
     //失去焦点
-    if (type === 'num' && Number(iptValue) == NaN) {
-      setIptValue('');
+    if (type === 'num') {
+      const val = Number(iptValue);
+      if (isNaN(val)) {
+        setIptValue('');
+        handleIptChange && handleIptChange('');
+      } else {
+      const num = getNum(val);
+        if (val !== num) {
+          setIptValue(num);
+          handleIptChange && handleIptChange(num);
+        }
+      }
     }
     handleIptBlur && handleIptBlur();
   };
@@ -82,16 +91,9 @@ const Input: FC<InputProps & NativeInputProps> = (props) => {
       return setIptValue('');
     }
     const stepNum = step || 1;
-    if (step && max && Number(iptValue) + stepNum > max) {
-      handleNumChange && handleNumChange(max);
-      return setIptValue(max);
-    }
-    if (step && min && Number(iptValue) + stepNum < min) {
-      handleNumChange && handleNumChange(min);
-      return setIptValue(min);
-    }
-    handleNumChange && handleNumChange(Number(iptValue) + stepNum);
-    setIptValue(Number(iptValue) + stepNum);
+    const res = getNum(Number(iptValue) + stepNum);
+    handleNumChange && handleNumChange(res);
+    setIptValue(res);
   };
   const lowNum = () => {
     //减
@@ -99,13 +101,20 @@ const Input: FC<InputProps & NativeInputProps> = (props) => {
       return setIptValue('');
     }
     const stepNum = step || 1;
-    if (step && min && Number(iptValue) - stepNum < min) {
-      handleNumChange && handleNumChange(min);
-      return setIptValue(min);
-    }
-    handleNumChange && handleNumChange(Number(iptValue) - stepNum);
-    setIptValue(Number(iptValue) - stepNum);
+    const res = getNum(Number(iptValue) - stepNum);
+    handleNumChange && handleNumChange(res);
+    setIptValue(res);
   };
+  // 获取数字框范围内的值
+  const getNum = (num: number) => {
+    if (step && (typeof max === 'number') && num > max) {
+      return max;
+    }
+    if (step && (typeof min === 'number') && num < min) {
+      return min;
+    }
+    return num;
+  }
   const iptType = useMemo(() => {
     if (showTogglePwd && type === 'password') {
       return pwdIptState ? 'password' : 'text';


### PR DESCRIPTION
1、当 min 或 max 为 0 时，加减箭头的函数判断有误，会将 0 判断为 false，所以改成了 typeof 判断
2、失去焦点是判断有误，NaN == NaN 为 false，改成 isNaN 判断
3、失去焦点加上对值的范围判断，需在 min ~ max 之内
(以上均是对 num 类型的输入框进行的修改操作，未影响其他逻辑)