### PR TITLE
fix: 重写inputPro点击逻辑

### DIFF
--- a/packages/concis-react/src/InputPro/index.tsx
+++ b/packages/concis-react/src/InputPro/index.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useContext, useMemo, forwardRef } from 'react';
+import React, { useState, useEffect, useContext, useMemo, forwardRef, useRef } from 'react';
 import { CSSTransition } from 'react-transition-group';
-import { on, off } from '../common_utils/dom/event';
+import { onClickOutSide } from '../common_utils/dom/event';
 import { GlobalConfigProps } from '../GlobalConfig/interface';
 import cs from '../common_utils/classNames';
 import { globalCtx } from '../GlobalConfig';
@@ -24,6 +24,7 @@ const InputPro = (props, ref) => {
 
   const [value, setValue] = useState('');
   const [isFocus, setIsFocus] = useState(false);
+  const inputProEl = useRef<HTMLDivElement>(null);
 
   const { prefixCls, darkTheme, globalColor } = useContext(globalCtx) as GlobalConfigProps;
 
@@ -43,9 +44,9 @@ const InputPro = (props, ref) => {
   }, [formCtx.submitStatus]);
 
   useEffect(() => {
-    on(window, 'click', reset)();
+    const destoryEvent = onClickOutSide(inputProEl, reset);
     return () => {
-      off(window, 'click', reset)();
+      destoryEvent();
     };
   }, []);
 
@@ -115,8 +116,14 @@ const InputPro = (props, ref) => {
     <div
       className={classNames}
       style={{ ...style, '--select-color': globalColor || defaultInputProColor } as any}
-      onClick={(e) => e.stopPropagation()}
-      ref={ref}
+      ref={(node) => {
+        inputProEl.current = node;
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref && typeof ref === 'object') {
+          ref.current = node;
+        }
+      }}
     >
       <Input
         placeholder="请输入"

--- a/packages/concis-react/src/common_utils/dom/event.ts
+++ b/packages/concis-react/src/common_utils/dom/event.ts
@@ -1,3 +1,5 @@
+import { RefObject } from 'react';
+
 function on(
   el: any,
   eventName: string,
@@ -6,6 +8,21 @@ function on(
 ) {
   return function () {
     el && el.addEventListener(eventName, handler, options || false);
+  };
+}
+
+function onClickOutSide(el: RefObject<HTMLElement> | HTMLElement, handler: EventListener) {
+  if (!(el instanceof HTMLElement)) {
+    el = el.current;
+  }
+  const clickOutsideHandler = function (e: MouseEvent) {
+    if (el && !(el as HTMLElement).contains(e.target as HTMLElement)) {
+      handler.call(this, e);
+    }
+  };
+  window.addEventListener('mousedown', clickOutsideHandler);
+  return function () {
+    window.removeEventListener('mousedown', clickOutsideHandler);
   };
 }
 
@@ -20,4 +37,4 @@ function off(
   };
 }
 
-export { on, off };
+export { on, off, onClickOutSide };


### PR DESCRIPTION
上一版的inputPro在页面同时存在多个inputPro组件时，点击一个后再点击另外一个，原来那个不会自动消失，原因是最外层div元素click事件被阻止，看git记录是为了修复**组件点击禁用option,列表仍会消失**的bug。