### PR TITLE
Add support for custom tooltip component in Popover

### DIFF
--- a/packages/concis-react/src/Popover/demos/index5.tsx
+++ b/packages/concis-react/src/Popover/demos/index5.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Popover, Button, Space } from 'concis';
+
+const CustomTooltip = () => (
+  <div style={{ padding: '10px', backgroundColor: '#f0f0f0', borderRadius: '4px' }}>
+    <h4 style={{ margin: 0, color: '#1d2129' }}>Custom Tooltip</h4>
+    <p style={{ margin: '5px 0', color: '#4e5969' }}>This is a custom tooltip component.</p>
+    <p style={{ margin: '5px 0', color: '#4e5969' }}>You can customize this as needed.</p>
+  </div>
+);
+
+export default function CustomTooltipDemo() {
+  return (
+    <Space>
+      <Popover
+        type="click"
+        style={{ padding: '0 0 15px 15px' }}
+        align="bottom"
+        customTooltip={<CustomTooltip />}
+      >
+        <Button type="primary" width={120} height={30}>
+          Click with Custom Tooltip
+        </Button>
+      </Popover>
+      <Popover
+        type="hover"
+        style={{ padding: '0 0 15px 15px' }}
+        align="top"
+        customTooltip={<CustomTooltip />}
+      >
+        <Button type="primary" width={120} height={30}>
+          Hover with Custom Tooltip
+        </Button>
+      </Popover>
+    </Space>
+  );
+}
+

--- a/packages/concis-react/src/Popover/index.md
+++ b/packages/concis-react/src/Popover/index.md
@@ -44,6 +44,12 @@ Declare a separate `ref` through `useRef` and pass it to `Popover`, and call `re
 
 <code src="./demos/index4.tsx"></code>
 
+## Custom Tooltip
+
+Use `customTooltip` prop to provide a custom tooltip component.
+
+<code src="./demos/index5.tsx"></code>
+
 ## API
 
 | Name            | Description                     | Type              | Default  |
@@ -58,3 +64,5 @@ Declare a separate `ref` through `useRef` and pass it to `Popover`, and call `re
 | defaultShow     | Show bubble cards by default    | `boolean`         | `false`  |
 | closeDeps       | Bubble card close dependencies  | `any[]`           | `[]`     |
 | onVisibleChange | Card show hide callback         | `Function`        | `--`     |
+| customTooltip  | Custom tooltip component           | `ReactNode`             | `-`       |
+

--- a/packages/concis-react/src/Popover/index.md
+++ b/packages/concis-react/src/Popover/index.md
@@ -64,5 +64,5 @@ Use `customTooltip` prop to provide a custom tooltip component.
 | defaultShow     | Show bubble cards by default    | `boolean`         | `false`  |
 | closeDeps       | Bubble card close dependencies  | `any[]`           | `[]`     |
 | onVisibleChange | Card show hide callback         | `Function`        | `--`     |
-| customTooltip  | Custom tooltip component           | `ReactNode`             | `-`       |
+| customTooltip  | Custom tooltip component         | `ReactNode`       | `-`      |
 

--- a/packages/concis-react/src/Popover/index.tsx
+++ b/packages/concis-react/src/Popover/index.tsx
@@ -27,6 +27,7 @@ const Popover = forwardRef<PopoverRef, popoverProps>((props, ref) => {
     defaultShow = false,
     closeDeps,
     onVisibleChange,
+    customTooltip,
   } = props;
   const showBtnRef = useRef();
   const dialogRef = useRef();
@@ -140,7 +141,7 @@ const Popover = forwardRef<PopoverRef, popoverProps>((props, ref) => {
                 onClick={(e) => e.stopPropagation()}
                 ref={dialogRef as any}
               >
-                {content}
+              {customTooltip || content}
               </div>
             </React.Fragment>
           </CSSTransition>

--- a/packages/concis-react/src/Popover/index.zh-CN.md
+++ b/packages/concis-react/src/Popover/index.zh-CN.md
@@ -63,5 +63,5 @@ toc: content
 | defaultShow     | 默认显示气泡卡片               | `boolean`         | `false`  |
 | closeDeps       | 气泡卡片关闭依赖项             | `any[]`           | `[]`     |
 | onVisibleChange | 卡片显示隐藏回调               | `Function`        | `--`     |
-| customTooltip  | 自定义 Tooltip 组件             | `ReactNode`       | `-`      |
+| customTooltip   | 自定义 Tooltip 组件            | `ReactNode`       | `-`      |
 

--- a/packages/concis-react/src/Popover/index.zh-CN.md
+++ b/packages/concis-react/src/Popover/index.zh-CN.md
@@ -43,6 +43,12 @@ toc: content
 
 <code src="./demos/index4.tsx"></code>
 
+## 自定义 Tooltip
+
+通过 `customTooltip` 属性提供自定义的 Tooltip 组件。
+
+<code src="./demos/index5.tsx"></code>
+
 ## API
 
 | Name            | Description                    | Type              | Default  |
@@ -57,3 +63,5 @@ toc: content
 | defaultShow     | 默认显示气泡卡片               | `boolean`         | `false`  |
 | closeDeps       | 气泡卡片关闭依赖项             | `any[]`           | `[]`     |
 | onVisibleChange | 卡片显示隐藏回调               | `Function`        | `--`     |
+| customTooltip  | 自定义 Tooltip 组件             | `ReactNode`       | `-`      |
+

--- a/packages/concis-react/src/Popover/interface.ts
+++ b/packages/concis-react/src/Popover/interface.ts
@@ -49,6 +49,10 @@ interface popoverProps {
    * @description 卡片显示隐藏回调
    */
   onVisibleChange?: Function;
+  /**
+   * @description Custom tooltip as component
+   */
+  customTooltip?: ReactNode;
 }
 
 type alignStyle = {


### PR DESCRIPTION
**Description:**

This PR adds a new `customTooltip` prop to the Popover component, allowing users to provide their own custom tooltip component. Resolved issue #101 

**Changes:**

- Added `customTooltip` prop to Popover component.
- Updated Popover component to render the custom tooltip if provided.
- Ensured backward compatibility with existing functionality.
- Updated documentation to include the new `customTooltip` prop.
- Added new demo as index5.tsx

**Files Changed:**

- `packages/concis-react/src/Popover/index.tsx`
- `packages/concis-react/src/Popover/interface.ts`
- `packages/concis-react/src/Popover/index.md`
- `packages/concis-react/src/Popover/index.zh-CN.md`

